### PR TITLE
Add option Callback(f, raw=...) to apply f to raw  model instead of expose(model)

### DIFF
--- a/LICENCE.md
+++ b/LICENCE.md
@@ -1,4 +1,4 @@
-The MLJ.jl package is licensed under the MIT "Expat" License:
+The IterationControl.jl package is licensed under the MIT "Expat" License:
 
 > Copyright (c) 2021: Anthony Blaom
 > 

--- a/src/api.jl
+++ b/src/api.jl
@@ -41,6 +41,11 @@ ingest!(model, data) = throw(err_ingest(model))
 # internal part of the model, rather than `model` directly:
 expose(model) = model
 
+# switch for expose; not to be overloaded:
+expose(model, raw) = expose(model, Val(raw))
+expose(model, ::Val{true}) = model
+expose(model, ::Val{false}) = expose(model)
+
 
 # -------------------------------------------------------------------
 # # CONTROL METHODS

--- a/src/controls.jl
+++ b/src/controls.jl
@@ -141,27 +141,30 @@ struct Callback{F<:Function}
     f::F
     stop_if_true::Bool
     stop_message::Union{String,Nothing}
+    raw::Bool
 end
 
 # constructor:
 Callback(f::Function;
          stop_if_true=false,
-         stop_message=nothing) = Callback(f, stop_if_true, stop_message)
+         stop_message=nothing,
+         raw=false) = Callback(f, stop_if_true, stop_message, raw)
 Callback(; f=identity, kwargs...) = Callback(f, kwargs...)
 
 @create_docs(Callback,
              header="Callback(f=_->nothing, stop_if_true=false, "*
-             "stop_message=nothing)",
+             "stop_message=nothing, raw=false)",
              example="Callback(m->put!(v, my_loss_function(m))",
              body="Call `f(IterationControl.expose(model))`, where "*
-             "`model` is the object being iterated. "*
-             "(If not overloaded, `expose` falls back to `identity`.) "*
+             "`model` is the object being iterated, unless `raw=true`, in "*
+             "which case call `f(model)` (guaranteed if `expose` has not been "*
+             "overloaded.) "*
              "If `stop_if_true` is `true`, then trigger an early stop "*
              "if the value returned by `f` is `true`, logging the "*
              "`stop_message` if specified. ")
 
 function update!(c::Callback, model, verbosity, state=(done=false, ))
-    r = c.f(expose(model))
+    r = c.f(expose(model, c.raw))
     done = (c.stop_if_true && r isa Bool && r) ? true : false
     return (done=done,)
 end

--- a/src/wrapped_controls.jl
+++ b/src/wrapped_controls.jl
@@ -39,16 +39,16 @@ _pred(predicate) = predicate
 _pred(predicate::Int) = t -> mod(t + 1, predicate) == 0
 
 """
-    IterationControl.skip(control, predicate::Union{Function,Int}=1)
+    IterationControl.skip(control, predicate=1)
 
 An iteration control wrapper.
+
+If `predicate` is an **integer**, `n`: Apply `control` on every `n`
+calls to apply the wrapper, starting with the `n`th call.
 
 If `predicate` is a **function**: Apply `control` as usual when
 `predicate(t + 1)` is `true` but otherwise skip. Here `t` is the
 number of calls to apply the wrapper so far.
-
-If `predicate` is an **integer**, `n`: Apply `control` on every `n`
-calls to apply the wrapper, starting with the `n`th call.
 
 """
 skip(control; predicate::Int=1) = Skip(control, _pred(predicate))

--- a/test/train.jl
+++ b/test/train.jl
@@ -1,19 +1,45 @@
-m = SquareRooter(4)
-report = IC.train!(m, Step(2),  NotANumber(), NumberLimit(3); verbosity=0);
-@test report[1] == (Step(2), NamedTuple())
-@test report[2] == (NotANumber(), (done=false, log=""))
-report[3] == (NumberLimit(3),
-                    (done=true,
-                     log="Early stop triggered by NumberLimit(3) "*
-                     "stopping criterion. "))
+@testset "basic integration" begin
+    m = SquareRooter(4)
+    report = IC.train!(m, Step(2),  NotANumber(), NumberLimit(3); verbosity=0);
+    @test report[1] == (Step(2), NamedTuple())
+    @test report[2] == (NotANumber(), (done=false, log=""))
+    report[3] == (NumberLimit(3),
+                  (done=true,
+                   log="Early stop triggered by NumberLimit(3) "*
+                   "stopping criterion. "))
 
-m = SquareRooter(4)
-@test_logs((:info, r"Early stop triggered by Num"),
-           IC.train!(m, Step(2),  NotANumber(), NumberLimit(3)));
-@test_logs((:info, r"Using these controls"),
-           (:info, r"Steping model for 2 iterations"),
-           (:info, r"Steping model for 2 iterations"),
-           (:info, r"Steping model for 2 iterations"),
-           (:info, r"Early stop triggered by NumberLimit"),
-           IC.train!(m, Step(2),  NotANumber(), NumberLimit(3); verbosity=2));
+    m = SquareRooter(4)
+    @test_logs((:info, r"Early stop triggered by Num"),
+               IC.train!(m, Step(2),  NotANumber(), NumberLimit(3)));
+    @test_logs((:info, r"Using these controls"),
+               (:info, r"Steping model for 2 iterations"),
+               (:info, r"Steping model for 2 iterations"),
+               (:info, r"Steping model for 2 iterations"),
+               (:info, r"Early stop triggered by NumberLimit"),
+               IC.train!(m, Step(2), NotANumber(), NumberLimit(3); verbosity=2));
+end
 
+struct WrappedSquareRooter
+    s::SquareRooter
+end
+
+@testset "expose and Callback(..., raw=true)" begin
+    IC.train!(w::WrappedSquareRooter, n) = IC.train!(w.s, n)
+    IC.loss(w::WrappedSquareRooter) = IC.loss(w.s)
+    IC.train!(w::WrappedSquareRooter, n) = IC.train!(w.s, n)
+    IC.expose(w::WrappedSquareRooter) = w.s
+
+    wrapper = WrappedSquareRooter(SquareRooter(4))
+
+    roots = Any[]
+    wrappers = Any[]
+
+    g(w) = push!(wrappers, deepcopy(w))
+
+    c1 = Callback(s->push!(roots, s.root))
+    c2 = Callback(g, raw=true)
+
+    IC.train!(wrapper, Step(1), c1, c2, NumberLimit(2), verbosity=0)
+
+    @test map(w -> w.s.root, wrappers) ≈ roots
+end


### PR DESCRIPTION
New docstring:

```
  Callback(f=_->nothing, stop_if_true=false, stop_message=nothing, raw=false)

  An iteration control, as in Callback(m->put!(v, my_loss_function(m)). 

  Call f(IterationControl.expose(model)), where model is the object being iterated, unless
  raw=true, in which case call f(model) (guaranteed if expose has not been overloaded.) If
  stop_if_true is true, then trigger an early stop if the value returned by f is true,
  logging the stop_message if specified. 
```