### PR TITLE
Replace `debug` wrapper with more general `with_state_do` wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,9 +208,9 @@ There are also three control wrappers to modify a control's behavior:
 
 wrapper                                            | description
 ---------------------------------------------------|-------------------------------------------------------------------------
-`IterationControl.skip(control, predicate=1)`      | Apply `control` every `predicate` applications of the control wrapper (can also be a function; see doc-string)
-`IterationControl.louder(control, by=1)`           | Increase the verbosity level of `control` by the specified value (negative values lower verbosity)
-`IterationControl.debug(control)`                  | Apply `control` but also log its state to `Info` (at any `verbosity` level)
+`IterationControl.skip(control; predicate=1)`      | Apply `control` every `predicate` applications of the control wrapper (can also be a function; see doc-string)
+`IterationControl.louder(control; by=1)`           | Increase the verbosity level of `control` by the specified value (negative values lower verbosity)
+`IterationControl.with_state_do(control; f=...)`   | Apply control *and* call `f(x)` where `x` is the internal state of control; useful for debugging. Default `f` logs state to `Info`. **Warning**: internal control state is not yet part of public API.
 `IterationControl.composite(controls...)`          | Apply each `control` in `controls` in sequence; mostly for under-the-hood use
 
 > Table 2. Wrapped controls

--- a/src/IterationControl.jl
+++ b/src/IterationControl.jl
@@ -41,5 +41,6 @@ include("wrapped_controls.jl")
 include("controls.jl")
 include("train.jl")
 include("square_rooter.jl")
+include("deprecated.jl")
 
 end # module

--- a/src/deprecated.jl
+++ b/src/deprecated.jl
@@ -1,0 +1,5 @@
+# # Debug
+
+Base.@deprecate debug(c) with_state_do(c)
+
+

--- a/test/deprecated.jl
+++ b/test/deprecated.jl
@@ -1,0 +1,1 @@
+@test_deprecated IC.debug(NumberLimit(2))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -39,3 +39,6 @@ end
     include("train.jl")
 end
 
+@testset "deprecated" begin
+    include("deprecated.jl")
+end

--- a/test/wrapped_controls.jl
+++ b/test/wrapped_controls.jl
@@ -19,14 +19,14 @@
     @test_logs (:warn, r"A ") IC.takedown(c, 1, state)
 end
 
-@testset "debug" begin
+@testset "with_state_do" begin
     m = SquareRooter(4)
     test_controls = [Step(2), InvalidValue(), GL(), Callback()]
     _info = fill((:info, r""), 2*length(test_controls))
 
     @test_logs(_info...,
                for c in test_controls
-               d = IC.debug(c)
+               d = IC.with_state_do(c)
                state = IC.update!(c, m, 1, 1)
                @test state == IC.update!(d, m, 1, 1)
                state_c = IC.update!(c, m, 0, 2, state)
@@ -34,6 +34,13 @@ end
                @test state_c == state_c
                @test IC.done(c, state_c) == IC.done(d, state_d)
                end)
+
+    # integration test:
+    m = SquareRooter(4)
+    v = Any[]
+    f(state) = push!(v, state.new_iterations)
+    IC.train!(m, IC.with_state_do(Step(2), f=f), NumberLimit(10))
+    @test v == 2:2:20
 end
 
 @testset "skip" begin


### PR DESCRIPTION
Adds `with_state_do` and deprecates `debug`, which it generalizes by adding a kwarg `f` whose default reproduces the old behaviour. 

Here's the doc-string:

---
    IterationControl.with_state_do(control,
                                  f=x->@info "\$(typeof(control)) state: \$x")

Wrap `control` to give access to it's internal state. Acts exactly
like `control` except that `f` is called on the internal state of
`control`. If `f` is not specified, the control type and state are
logged to `Info` at every update (useful for debugging new controls).

**Warning.** The internal state of a control is not yet considered
part of the public interface and could change between in any pre 1.0
release of IterationControl.jl.

FYI: @awadell1